### PR TITLE
build g2full

### DIFF
--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -1,0 +1,42 @@
+# Build the gsas2full self installer starting with Linux
+#
+#conda package on Mac (Intel) & Linux
+#
+name: build gsas2full
+
+#on: [push, pull_request, workflow_dispatch]   # why build on pull request?
+#on: [push, workflow_dispatch]
+on: [workflow_dispatch]
+# run on all platforms this if any of the following change: 
+#    install/gitstrap.py
+#    install/g2complete
+#    install/g2full
+
+jobs:
+  build:
+    name: gsas2full build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+#        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
+#        os: [macos-latest]   # testing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up conda
+        #uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@030178870c779d9e5e1b4e563269f3aa69b04081 # v3.0.3 
+                                               # (using hash to protect secrets)
+        with:
+          activate-environment: build
+          environment-file: install/g2complete/conda-build-env.yml
+          python-version: 3.11
+          miniforge-version: latest
+
+      - name: diagnostics
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -63,6 +63,13 @@ jobs:
           CONDA_SOLVER=classic constructor g2full   # can't use mamba in constructor 3.7
           ls -lt *.sh
           
+      - name: Upload artifact  # creates zip file with website contents
+        uses: actions/upload-pages-artifact@v3
+        with:
+            path: install
+            name: constructor
+            retention-days: 1
+          
 #      - name: diagnostics
 #        shell: bash -l {0}
 #        run: |

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -29,7 +29,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-                  
+	
+      - name: Test use of ls/dir
+        shell: bash -l {0}
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+             dir install
+          else
+             ls -lt install
+          fi
+
       - name: Set up conda  # note that conda-build-env.yml fixes Python & numpy versions (alas)
         #uses: conda-incubator/setup-miniconda@v2
         uses: conda-incubator/setup-miniconda@030178870c779d9e5e1b4e563269f3aa69b04081 # v3.0.3 using hash for security

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -18,10 +18,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-#        os: [ubuntu-latest, windows-latest, macos-latest]
+#        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
 #
 #        os: [ubuntu-latest]  # worked
-        os: [macos-latest]   # testing
+#        os: [macos-latest]   # running
+        os: [macos-macos-14]   # testing
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -22,9 +22,9 @@ jobs:
 #         os: [ubuntu-latest, windows-latest]
 #
 #        os: [ubuntu-latest]
-        os: [macos-latest]   # worked (intel)
+#        os: [macos-latest]   # worked (intel)
 #        os: [macos-14]   # worked (M1)
-#        os: [windows-latest]   # worked (M1)
+        os: [windows-latest]
 
     steps:
       - name: Checkout

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -66,13 +66,13 @@ jobs:
         shell: bash -l {0}
         run: |
           cd install
-          #conda activate construct
+#          conda activate construct
           CONDA_SOLVER=classic constructor g2full   # can't use mamba in constructor 3.7
-          # if [ "$RUNNER_OS" == "Windows" ]; then
-          #    dir *.exe
-          # else
-          #    ls -lt *.sh
-          # fi
+#          if [ "$RUNNER_OS" == "Windows" ]; then
+#             dir *.exe
+#          else
+#             ls -lt *.sh
+#          fi
  
       - name: Test the g2full installer
         shell: bash -l {0}

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -19,11 +19,12 @@ jobs:
     strategy:
       matrix:
 #        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
+         os: [ubuntu-latest, windows-latest]
 #
 #        os: [ubuntu-latest]  # worked
 #        os: [macos-latest]   # worked (intel)
 #        os: [macos-14]   # worked (M1)
-        os: [windows-latest]   # worked (M1)
+#        os: [windows-latest]   # worked (M1)
 
     steps:
       - name: Checkout
@@ -54,37 +55,29 @@ jobs:
         run: |
           cd install
           python setgitversion.py ../_gsas2
-          #conda build g2complete --output-folder ~/build
-          #ls -l ~/build
-          #ls -l ~/build/*/*.tar.*
-          conda build g2complete --output-folder C:/tmp/builds
-          
+          if [ "$RUNNER_OS" == "windows" ]; then
+             conda build g2complete --output-folder C:/tmp/builds
+          else
+             conda build g2complete --output-folder ~/build
+          fi
+
       - name: create conda gsas2full installer
         shell: bash -l {0}
         run: |
           cd install
           conda activate construct
           CONDA_SOLVER=classic constructor g2full   # can't use mamba in constructor 3.7
-          #ls -lt *.sh
-          
-      - name: Upload artifact  # creates zip file with website contents
+          if [ "$RUNNER_OS" == "windows" ]; then
+             dir *.exe
+          else
+             ls -lt *.sh
+          fi
+
+      # for testing, upload the .sh/.exe file created here
+      - name: Upload artifact  # creates zip file with directory contents
         uses: actions/upload-pages-artifact@v3
         with:
             path: install
             name: constructor
             retention-days: 1
-          
-#      - name: diagnostics
-#        shell: bash -l {0}
-#        run: |
-#          conda info
-#          conda list
-#      - name: right place for build?
-#        shell: bash -l {0}
-#        run: |
-#          cd install
-#          ls -l
-#          exit 1
-
-
-
+    

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -25,23 +25,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         
-      - name: right place for build?
-        shell: bash -l {0}
-        run: |
-          cd install
-          ls -l
-          exit 1
+#      - name: right place for build?
+#        shell: bash -l {0}
+#        run: |
+#          cd install
+#          ls -l
+#          exit 1
 
-      - name: Set up conda
+      - name: Set up conda  # note that conda-build-env.yml fixes Python & numpy versions (alas)
         #uses: conda-incubator/setup-miniconda@v2
-        uses: conda-incubator/setup-miniconda@030178870c779d9e5e1b4e563269f3aa69b04081 # v3.0.3 
-                                               # (using hash to protect secrets)
+        uses: conda-incubator/setup-miniconda@030178870c779d9e5e1b4e563269f3aa69b04081 # v3.0.3 using hash for security
         with:
           activate-environment: build
           environment-file: install/g2complete/conda-build-env.yml
-          python-version: 3.11
           miniforge-version: latest
 
+      # get the GSAS-II sources
+      - name: Get GSAS-II
+        run: |
+          git clone --depth 50 https://github.com/AdvancedPhotonSource/GSAS-II.git _gsas2          
+
+      - name: create conda gsas2complete package
+        shell: bash -l {0}
+        run: |
+          cd install
+          python setgitversion.py ../_gsas2
+          conda build g2complete --output-folder ../_builds
+          
 #      - name: diagnostics
 #        shell: bash -l {0}
 #        run: |

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -23,7 +23,7 @@ jobs:
 #
 #        os: [ubuntu-latest]
 #        os: [macos-latest]   # worked (intel)
-        os: [macos-14]   # worked (M1)
+        os: [macos-14, windows-latest]   # worked (M1)
 #        os: [windows-latest]
 
     steps:
@@ -54,10 +54,11 @@ jobs:
         shell: bash -l {0}
         run: |
           cd install
-          python setgitversion.py ../_gsas2  ~/build
           if [ "$RUNNER_OS" == "Windows" ]; then
+             python setgitversion.py ../_gsas2 C:/tmp/builds
              conda build g2complete --output-folder C:/tmp/builds
           else
+             python setgitversion.py ../_gsas2  ~/build
              conda build g2complete --output-folder ~/build
           fi
 
@@ -73,14 +74,14 @@ jobs:
              ls -lt *.sh
           fi
  
-      - name: Test the g2full installer
-        shell: bash -l {0}
-        run: |
-          if [ "$RUNNER_OS" != "Windows" ]; then
-            rm -rf ~/build
-            ls -lt install/*.sh
-            bash `ls install/*.sh` -b -p ~/testinstall
-          fi
+      # - name: Test the g2full installer
+      #   shell: bash -l {0}
+      #   run: |
+      #     if [ "$RUNNER_OS" != "Windows" ]; then
+      #       rm -rf ~/build
+      #       ls -lt install/*.sh
+      #       bash `ls install/*.sh` -b -p ~/testinstall
+      #     fi
 
       # for testing, upload the .sh/.exe file created here
       - name: Upload artifact  # creates zip file with directory contents

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -65,7 +65,7 @@ jobs:
           cd install
           conda activate construct
           CONDA_SOLVER=classic constructor g2full   # can't use mamba in constructor 3.7
-          ls -lt *.sh
+          #ls -lt *.sh
           
       - name: Upload artifact  # creates zip file with website contents
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -21,8 +21,8 @@ jobs:
 #        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
 #         os: [ubuntu-latest, windows-latest]
 #
-        os: [ubuntu-latest]
-#        os: [macos-latest]   # worked (intel)
+#        os: [ubuntu-latest]
+        os: [macos-latest]   # worked (intel)
 #        os: [macos-14]   # worked (M1)
 #        os: [windows-latest]   # worked (M1)
 

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -23,8 +23,8 @@ jobs:
 #
 #        os: [ubuntu-latest]
 #        os: [macos-latest]   # worked (intel)
-        os: [macos-14, windows-latest]   # worked (M1)
-#        os: [windows-latest]
+#        os: [macos-14]   # worked (M1)
+        os: [windows-latest]
 
     steps:
       - name: Checkout
@@ -68,20 +68,22 @@ jobs:
           cd install
           #conda activate construct
           CONDA_SOLVER=classic constructor g2full   # can't use mamba in constructor 3.7
-          if [ "$RUNNER_OS" == "Windows" ]; then
-             dir *.exe
-          else
-             ls -lt *.sh
-          fi
+          # if [ "$RUNNER_OS" == "Windows" ]; then
+          #    dir *.exe
+          # else
+          #    ls -lt *.sh
+          # fi
  
-      # - name: Test the g2full installer
-      #   shell: bash -l {0}
-      #   run: |
-      #     if [ "$RUNNER_OS" != "Windows" ]; then
-      #       rm -rf ~/build
-      #       ls -lt install/*.sh
-      #       bash `ls install/*.sh` -b -p ~/testinstall
-      #     fi
+      - name: Test the g2full installer
+        shell: bash -l {0}
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            dir install\*.exe
+          else
+            ls -lt install/*.sh
+#            rm -rf ~/build
+#            bash `ls install/*.sh` -b -p ~/testinstall
+          fi
 
       # for testing, upload the .sh/.exe file created here
       - name: Upload artifact  # creates zip file with directory contents

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -22,7 +22,7 @@ jobs:
 #
 #        os: [ubuntu-latest]  # worked
 #        os: [macos-latest]   # running
-        os: [macos-macos-14]   # testing
+        os: [macos-14]   # testing
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -54,7 +54,8 @@ jobs:
         run: |
           cd install
           python setgitversion.py ../_gsas2
-          conda build g2complete --output-folder ~/build
+#          conda build g2complete --output-folder ~/build
+          conda build g2complete --output-folder C:/tmp/builds
           ls -l ~/build
           ls -l ~/build/*/*.tar.*
           

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -19,9 +19,9 @@ jobs:
     strategy:
       matrix:
 #        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
-         os: [ubuntu-latest, windows-latest]
+#         os: [ubuntu-latest, windows-latest]
 #
-#        os: [ubuntu-latest]  # worked
+        os: [ubuntu-latest]
 #        os: [macos-latest]   # worked (intel)
 #        os: [macos-14]   # worked (M1)
 #        os: [windows-latest]   # worked (M1)
@@ -41,9 +41,9 @@ jobs:
       - name: install to old conda/constructor and then back to latest
         shell: bash -l {0}
         run: |
-          conda create -n construct constructor=3.3 python=3.10 -y
+          conda create -n construct constructor -y
           conda activate construct
-          conda install constructor=3.7 -y
+          #conda install constructor=3.7 -y
           
       - name: Get GSAS-II sources
         shell: bash -l {0}
@@ -66,11 +66,21 @@ jobs:
         run: |
           cd install
           conda activate construct
-          CONDA_SOLVER=classic constructor g2full   # can't use mamba in constructor 3.7
           if [ "$RUNNER_OS" == "Windows" ]; then
+            CONDA_SOLVER=classic constructor g2full -c C:/tmp/builds  # can't use mamba in constructor 3.7
              dir *.exe
           else
+            CONDA_SOLVER=classic constructor g2full -c ~/build  # can't use mamba in constructor 3.7
              ls -lt *.sh
+          fi
+ 
+      - name: Test the g2full installer
+        shell: bash -l {0}
+        run: |
+          if [ "$RUNNER_OS" != "Windows" ]; then
+            rm -rf ~/build
+            ls -lt install/*.sh
+            bash `ls install/*.sh` -b -p ~/testinstall
           fi
 
       # for testing, upload the .sh/.exe file created here

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           cd install
           python setgitversion.py ../_gsas2
-          if [ "$RUNNER_OS" == "windows" ]; then
+          if [ "$RUNNER_OS" == "Windows" ]; then
              conda build g2complete --output-folder C:/tmp/builds
           else
              conda build g2complete --output-folder ~/build
@@ -67,7 +67,7 @@ jobs:
           cd install
           conda activate construct
           CONDA_SOLVER=classic constructor g2full   # can't use mamba in constructor 3.7
-          if [ "$RUNNER_OS" == "windows" ]; then
+          if [ "$RUNNER_OS" == "Windows" ]; then
              dir *.exe
           else
              ls -lt *.sh

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -24,7 +24,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+      - name: Revert to old conda/sonstructor and then back to latest
+        shell: bash -l {0}
+          conda install constructor=3.3
+          conda search 
+          conda install constructor=3.7
+          
       - name: Set up conda  # note that conda-build-env.yml fixes Python & numpy versions (alas)
         #uses: conda-incubator/setup-miniconda@v2
         uses: conda-incubator/setup-miniconda@030178870c779d9e5e1b4e563269f3aa69b04081 # v3.0.3 using hash for security
@@ -46,7 +51,7 @@ jobs:
           conda build g2complete --output-folder ~/build
           ls -l ~/build
           ls -l ~/build/*/*.tar.*
-          constructor g2full
+          CONDA_SOLVER=classic constructor g2full   # can't use mamba in constructor 3.7
           ls -lt *.sh
           
 #      - name: diagnostics

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -55,9 +55,9 @@ jobs:
           cd install
           python setgitversion.py ../_gsas2
           #conda build g2complete --output-folder ~/build
+          #ls -l ~/build
+          #ls -l ~/build/*/*.tar.*
           conda build g2complete --output-folder C:/tmp/builds
-          ls -l ~/build
-          ls -l ~/build/*/*.tar.*
           
       - name: create conda gsas2full installer
         shell: bash -l {0}

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -68,25 +68,14 @@ jobs:
           cd install
           CONDA_SOLVER=classic constructor g2full   # can't use mamba in constructor 3.7
 
-      - name: Test use of ls/dir
-        shell: bash -l {0}
-        run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-             dir install
-          else
-             ls -lt install
-          fi
-
       - name: Test the g2full installer
         shell: bash -l {0}
         run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-             dir install\*.exe
-          else
+          if [ "$RUNNER_OS" != "Windows" ]; then
              ls -lt install/*.sh
+             #rm -rf ~/build
+             #bash `ls install/*.sh` -b -p ~/testinstall
           fi
-#             #rm -rf ~/build
-#             #bash `ls install/*.sh` -b -p ~/testinstall
 
       # for testing, upload the .sh/.exe file created here
       - name: Upload artifact  # creates zip file with directory contents

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -33,8 +33,14 @@ jobs:
           environment-file: install/g2complete/conda-build-env.yml
           miniforge-version: latest
 
-      # get the GSAS-II sources
-      - name: Get GSAS-II
+      - name: install to old conda/constructor and then back to latest
+        shell: bash -l {0}
+        run: |
+          conda create -n construct constructor=3.3 python=3.10 -y
+          conda activate construct
+          conda install constructor=3.7 -y
+          
+      - name: Get GSAS-II sources
         shell: bash -l {0}
         run: |
           git clone --depth 50 https://github.com/AdvancedPhotonSource/GSAS-II.git _gsas2          
@@ -47,13 +53,6 @@ jobs:
           conda build g2complete --output-folder ~/build
           ls -l ~/build
           ls -l ~/build/*/*.tar.*
-
-      - name: Revert to old conda/constructor and then back to latest
-        shell: bash -l {0}
-        run: |
-          conda create -n construct constructor=3.3 python=3.10
-          conda activate construct
-          conda update constructor=3.7
           
       - name: create conda gsas2full installer
         shell: bash -l {0}

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -66,13 +66,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd install
-#          conda activate construct
           CONDA_SOLVER=classic constructor g2full   # can't use mamba in constructor 3.7
-#          if [ "$RUNNER_OS" == "Windows" ]; then
-#             dir *.exe
-#          else
-#             ls -lt *.sh
-#          fi
  
       - name: Test the g2full installer
         shell: bash -l {0}
@@ -81,8 +75,8 @@ jobs:
              dir install\*.exe
           else
              ls -lt install/*.sh
-#             rm -rf ~/build
-#             bash `ls install/*.sh` -b -p ~/testinstall
+             #rm -rf ~/build
+             #bash `ls install/*.sh` -b -p ~/testinstall
           fi
 
       # for testing, upload the .sh/.exe file created here

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -25,13 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         
-#      - name: right place for build?
-#        shell: bash -l {0}
-#        run: |
-#          cd install
-#          ls -l
-#          exit 1
-
       - name: Set up conda  # note that conda-build-env.yml fixes Python & numpy versions (alas)
         #uses: conda-incubator/setup-miniconda@v2
         uses: conda-incubator/setup-miniconda@030178870c779d9e5e1b4e563269f3aa69b04081 # v3.0.3 using hash for security
@@ -50,12 +43,23 @@ jobs:
         run: |
           cd install
           python setgitversion.py ../_gsas2
-          conda build g2complete --output-folder ../_builds
+          conda build g2complete --output-folder ~/build
+          ls -l ~/build
+          ls -l ~/build/*/*.tar.gz
+          constructor g2full
+          ls -lt *.sh
           
 #      - name: diagnostics
 #        shell: bash -l {0}
 #        run: |
 #          conda info
 #          conda list
+#      - name: right place for build?
+#        shell: bash -l {0}
+#        run: |
+#          cd install
+#          ls -l
+#          exit 1
+
 
 

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -78,11 +78,11 @@ jobs:
         shell: bash -l {0}
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
-            dir install\*.exe
+             dir install\*.exe
           else
-            ls -lt install/*.sh
-#            rm -rf ~/build
-#            bash `ls install/*.sh` -b -p ~/testinstall
+             ls -lt install/*.sh
+#             rm -rf ~/build
+#             bash `ls install/*.sh` -b -p ~/testinstall
           fi
 
       # for testing, upload the .sh/.exe file created here

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -24,14 +24,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
-      - name: Revert to old conda/sonstructor and then back to latest
-        shell: bash -l {0}
-        run: |
-          conda install constructor=3.3
-          conda search 
-          conda install constructor=3.7
-          
+                  
       - name: Set up conda  # note that conda-build-env.yml fixes Python & numpy versions (alas)
         #uses: conda-incubator/setup-miniconda@v2
         uses: conda-incubator/setup-miniconda@030178870c779d9e5e1b4e563269f3aa69b04081 # v3.0.3 using hash for security
@@ -54,6 +47,19 @@ jobs:
           conda build g2complete --output-folder ~/build
           ls -l ~/build
           ls -l ~/build/*/*.tar.*
+
+      - name: Revert to old conda/constructor and then back to latest
+        shell: bash -l {0}
+        run: |
+          conda create -n construct constructor=3.3 python=3.10
+          conda activate construct
+          conda update constructor=3.7
+          
+      - name: create conda gsas2full installer
+        shell: bash -l {0}
+        run: |
+          cd install
+          conda activate construct
           CONDA_SOLVER=classic constructor g2full   # can't use mamba in constructor 3.7
           ls -lt *.sh
           

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -54,7 +54,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd install
-          python setgitversion.py ../_gsas2
+          python setgitversion.py ../_gsas2  ~/build
           if [ "$RUNNER_OS" == "Windows" ]; then
              conda build g2complete --output-folder C:/tmp/builds
           else
@@ -66,11 +66,10 @@ jobs:
         run: |
           cd install
           conda activate construct
+          CONDA_SOLVER=classic constructor g2full   # can't use mamba in constructor 3.7
           if [ "$RUNNER_OS" == "Windows" ]; then
-            CONDA_SOLVER=classic constructor g2full -c C:/tmp/builds  # can't use mamba in constructor 3.7
              dir *.exe
           else
-            CONDA_SOLVER=classic constructor g2full -c ~/build  # can't use mamba in constructor 3.7
              ls -lt *.sh
           fi
  

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -1,4 +1,4 @@
-# Build the gsas2full self installer with Linux, MacOS-intel
+# Build the gsas2full self installer with Linux, MacOS-intel/ARM
 #
 #conda package on Mac (Intel) & Linux
 #
@@ -21,8 +21,10 @@ jobs:
 #        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
 #
 #        os: [ubuntu-latest]  # worked
-#        os: [macos-latest]   # running
-        os: [macos-14]   # testing
+#        os: [macos-latest]   # worked (intel)
+#        os: [macos-14]   # worked (M1)
+        os: [windows-latest]   # worked (M1)
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -23,8 +23,8 @@ jobs:
 #
 #        os: [ubuntu-latest]
 #        os: [macos-latest]   # worked (intel)
-#        os: [macos-14]   # worked (M1)
-        os: [windows-latest]
+        os: [macos-14]   # worked (M1)
+#        os: [windows-latest]
 
     steps:
       - name: Checkout
@@ -38,12 +38,12 @@ jobs:
           environment-file: install/g2complete/conda-build-env.yml
           miniforge-version: latest
 
-      - name: install to old conda/constructor and then back to latest
-        shell: bash -l {0}
-        run: |
-          conda create -n construct constructor -y
-          conda activate construct
-          #conda install constructor=3.7 -y
+#      - name: install to old conda/constructor and then back to latest
+#        shell: bash -l {0}
+#        run: |
+#          conda create -n construct constructor -y
+#          conda activate construct
+#          #conda install constructor=3.7 -y
           
       - name: Get GSAS-II sources
         shell: bash -l {0}

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -1,4 +1,4 @@
-# Build the gsas2full self installer starting with Linux
+# Build the gsas2full self installer with Linux, MacOS-intel
 #
 #conda package on Mac (Intel) & Linux
 #
@@ -19,8 +19,9 @@ jobs:
     strategy:
       matrix:
 #        os: [ubuntu-latest, windows-latest, macos-latest]
-        os: [ubuntu-latest]
-#        os: [macos-latest]   # testing
+#
+#        os: [ubuntu-latest]  # worked
+        os: [macos-latest]   # testing
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           cd install
           python setgitversion.py ../_gsas2
-#          conda build g2complete --output-folder ~/build
+          #conda build g2complete --output-folder ~/build
           conda build g2complete --output-folder C:/tmp/builds
           ls -l ~/build
           ls -l ~/build/*/*.tar.*

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -30,15 +30,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-#      - name: Test use of ls/dir
-#        shell: bash -l {0}
-#        run: |
-#          if [ "$RUNNER_OS" == "Windows" ]; then
-#             dir install
-#          else
-#             ls -lt install
-#          fi
-
       - name: Set up conda  # note that conda-build-env.yml fixes Python & numpy versions (alas)
         #uses: conda-incubator/setup-miniconda@v2
         uses: conda-incubator/setup-miniconda@030178870c779d9e5e1b4e563269f3aa69b04081 # v3.0.3 using hash for security
@@ -76,17 +67,26 @@ jobs:
         run: |
           cd install
           CONDA_SOLVER=classic constructor g2full   # can't use mamba in constructor 3.7
- 
-      - name: Test the g2full installer
+
+      - name: Test use of ls/dir
         shell: bash -l {0}
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
              dir install
           else
-             ls -lt install/*.sh
-             #rm -rf ~/build
-             #bash `ls install/*.sh` -b -p ~/testinstall
+             ls -lt install
           fi
+
+      - name: Test the g2full installer
+        shell: bash -l {0}
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+             dir install\*.exe
+          else
+             ls -lt install/*.sh
+          fi
+#             #rm -rf ~/build
+#             #bash `ls install/*.sh` -b -p ~/testinstall
 
       # for testing, upload the .sh/.exe file created here
       - name: Upload artifact  # creates zip file with directory contents

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -24,8 +24,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        
       - name: Revert to old conda/sonstructor and then back to latest
         shell: bash -l {0}
+        run: |
           conda install constructor=3.3
           conda search 
           conda install constructor=3.7
@@ -40,6 +42,7 @@ jobs:
 
       # get the GSAS-II sources
       - name: Get GSAS-II
+        shell: bash -l {0}
         run: |
           git clone --depth 50 https://github.com/AdvancedPhotonSource/GSAS-II.git _gsas2          
 

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -65,7 +65,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd install
-          conda activate construct
+          #conda activate construct
           CONDA_SOLVER=classic constructor g2full   # can't use mamba in constructor 3.7
           if [ "$RUNNER_OS" == "Windows" ]; then
              dir *.exe

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -30,14 +30,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Test use of ls/dir
-        shell: bash -l {0}
-        run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-             dir install
-          else
-             ls -lt install
-          fi
+#      - name: Test use of ls/dir
+#        shell: bash -l {0}
+#        run: |
+#          if [ "$RUNNER_OS" == "Windows" ]; then
+#             dir install
+#          else
+#             ls -lt install
+#          fi
 
       - name: Set up conda  # note that conda-build-env.yml fixes Python & numpy versions (alas)
         #uses: conda-incubator/setup-miniconda@v2
@@ -81,7 +81,7 @@ jobs:
         shell: bash -l {0}
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
-             dir install\*.exe
+             dir install
           else
              ls -lt install/*.sh
              #rm -rf ~/build

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-	
+
       - name: Test use of ls/dir
         shell: bash -l {0}
         run: |

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -24,6 +24,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        
+      - name: right place for build?
+        shell: bash -l {0}
+        run: |
+          cd install
+          ls -l
+          exit 1
 
       - name: Set up conda
         #uses: conda-incubator/setup-miniconda@v2
@@ -35,8 +42,10 @@ jobs:
           python-version: 3.11
           miniforge-version: latest
 
-      - name: diagnostics
-        shell: bash -l {0}
-        run: |
-          conda info
-          conda list
+#      - name: diagnostics
+#        shell: bash -l {0}
+#        run: |
+#          conda info
+#          conda list
+
+

--- a/.github/workflows/gsas2full.yml
+++ b/.github/workflows/gsas2full.yml
@@ -45,7 +45,7 @@ jobs:
           python setgitversion.py ../_gsas2
           conda build g2complete --output-folder ~/build
           ls -l ~/build
-          ls -l ~/build/*/*.tar.gz
+          ls -l ~/build/*/*.tar.*
           constructor g2full
           ls -lt *.sh
           

--- a/install/g2complete/conda-build-env.yml
+++ b/install/g2complete/conda-build-env.yml
@@ -1,0 +1,19 @@
+name: conda-build-env
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - wxpython
+  - numpy=1.26
+  - scipy
+  - matplotlib
+  - pyopengl
+  - conda
+  - constructor
+  - conda-build
+  - git 
+  - gitpython
+  - requests
+  - pillow
+  - h5py
+  - imageio

--- a/install/g2full/construct.yaml.template
+++ b/install/g2full/construct.yaml.template
@@ -3,6 +3,7 @@ version: **Version**
 #install_in_dependency_order: True
 
 channels:
+  - **gsas2complete-loc**
   - https://conda.anaconda.org/conda-forge
 
 conda_default_channels:
@@ -24,7 +25,6 @@ specs:
     - git
     - gitpython
     - pywin32                              [win]
-    #- C:\tmp\builds\win-64\gsas2complete-**Version**-0.tar.bz2 [win]
     - gsas2complete
 
 #exclude:

--- a/install/g2full/construct.yaml.template
+++ b/install/g2full/construct.yaml.template
@@ -24,8 +24,8 @@ specs:
     - git
     - gitpython
     - pywin32                              [win]
-    - C:\tmp\builds\win-64\gsas2complete-**Version**-0.tar.bz2 [win]
-    - ~/build/**OS**/gsas2complete-**Version**-0.tar.bz2 [not win]
+    #- C:\tmp\builds\win-64\gsas2complete-**Version**-0.tar.bz2 [win]
+    - gsas2complete
 
 #exclude:
 #  - qt                               [not osx]

--- a/install/setgitversion.py
+++ b/install/setgitversion.py
@@ -13,11 +13,12 @@ import wx
 import matplotlib as mpl
 import platform
 
-if len(sys.argv) < 2:
+if len(sys.argv) < 3:
     G2code = os.path.join(os.path.dirname(__file__),'GSAS2-code')
     raise Exception('setgitversion broken with only one arg')
 else:
     G2code = os.path.abspath(sys.argv[1])
+    G2buildLoc = os.path.abspath(sys.argv[2])
 if not os.path.exists(G2code):
     print(f'Path to GSAS-II code {G2code} not found')
     sys.exit()
@@ -46,11 +47,12 @@ wxversion = wx.__version__
 mplversion = mpl.__version__[:mpl.__version__.find('.',2)]
 pyversion = platform.python_version()
 if pyversion.find('.',2) > 0: pyversion = pyversion[:pyversion.find('.',2)]
-print ('GSAS-II version   {}'.format(G2version))
-print ('python version is {}'.format(pyversion))
-print ('numpy version is  {}'.format(npversion))
-print ('wx version is     {}'.format(wxversion))
-print ('MPL version is    {}'.format(mplversion))
+print (f'GSAS-II version   {G2version}')
+print (f'python version is {pyversion}')
+print (f'numpy version is  {npversion}')
+print (f'wx version is     {wxversion}')
+print (f'MPL version is    {mplversion}')
+print (f'g2complete in     {G2buildLoc}')
 
 for fil in ('g2complete/meta.yaml','g2complete/build.sh',
                 'g2complete/bld.bat',
@@ -60,11 +62,13 @@ for fil in ('g2complete/meta.yaml','g2complete/build.sh',
                 ):
     try:
         note = ''
-        if platform.machine() == 'aarch64' and os.path.exists(fil+'.Pitemplate'): # Raspberry Pi
-            fp = open(fil+'.Pitemplate','r')
-        else:
-            fp = open(fil+'.template','r')
+#        if platform.machine() == 'aarch64' and os.path.exists(fil+'.Pitemplate'): # Raspberry Pi
+#            fp = open(fil+'.Pitemplate','r')
+#        else:
+#            fp = open(fil+'.template','r')
+        fp = open(fil+'.template','r')
         out = fp.read().replace('**Version**',G2version)
+        
         fp.close()
     except FileNotFoundError:
         print('Skipping ',fil)
@@ -77,6 +81,7 @@ for fil in ('g2complete/meta.yaml','g2complete/build.sh',
         if 'linux-64' in out:
             print('changing for 32-bit linux')
             out = out.replace('linux-64','linux-32')
+    out = out.replace('**gsas2complete-loc**',G2buildLoc)
     out = out.replace('**pyversion**',pyversion)
     out = out.replace('**npversion**',npversion)
     out = out.replace('**wxversion**',wxversion)


### PR DESCRIPTION
Add code to build gsas2full via Actions

This includes a change to the constructor build process where gsas2complete is used from a local channel rather than is included as a file; seems to avoid [bug seen in unix self-installers](https://github.com/conda/constructor/issues/770). 